### PR TITLE
Stdlib ArrayRef template deduction guides

### DIFF
--- a/stdlib/include/llvm/ADT/ArrayRef.h
+++ b/stdlib/include/llvm/ADT/ArrayRef.h
@@ -469,6 +469,28 @@ namespace llvm {
     ~OwningArrayRef() { delete[] this->data(); }
   };
 
+  /// C++17 ArrayRef deduction guides
+  template <typename T>
+  ArrayRef(const T &) -> ArrayRef<T>;
+  template <typename T>
+  ArrayRef(const T *, size_t) -> ArrayRef<T>;
+  template <typename T>
+  ArrayRef(const T *, const T *) -> ArrayRef<T>;
+  template <typename T>
+  ArrayRef(const SmallVectorImpl<T> &Vec) -> ArrayRef<T>;
+  template <typename T, unsigned N>
+  ArrayRef(const SmallVector<T, N> &Vec) -> ArrayRef<T>;
+  template <typename T, typename A>
+  ArrayRef(const std::vector<T, A> &) -> ArrayRef<T>;
+  template <typename T, std::size_t N>
+  ArrayRef(const std::array<T, N> &Vec) -> ArrayRef<T>;
+  template <typename T>
+  ArrayRef(const ArrayRef<T> &Vec) -> ArrayRef<T>;
+  template <typename T>
+  ArrayRef(ArrayRef<T> &Vec) -> ArrayRef<T>;
+  template <typename T, size_t N>
+  ArrayRef(const T (&Arr)[N]) -> ArrayRef<T>;
+
   /// @name ArrayRef Convenience constructors
   /// @{
 


### PR DESCRIPTION
Adding template deduction guides so that ArrayRef initialization works without warnings.
